### PR TITLE
telegraf-s should mount /var/run/utmp

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -5,4 +5,4 @@ helm install --name polling --namespace tick ./telegraf-s/
 helm install --name hosts --namespace tick ./telegraf-ds/
 helm install --name alerts --namespace tick ./kapacitor/
 helm install --name dash --namespace tick ./chronograf/
-kkubectl get svc -w --namespace tick -l app=dash-chronograf
+kubectl get svc -w --namespace tick -l app=dash-chronograf

--- a/telegraf-s/templates/deployment.yaml
+++ b/telegraf-s/templates/deployment.yaml
@@ -21,9 +21,15 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
+        - name: varrunutmpro
+          mountPath: /var/run/utmp
+          readOnly: true
         - name: config
           mountPath: /etc/telegraf
       volumes:
+      - name: varrunutmpro
+        hostPath:
+          path: /var/run/utmp
       - name: config
         configMap:
           name: {{ template "fullname" . }}


### PR DESCRIPTION
`/var/run/utmp` is required by the telegraf-s deployment.

I'm not very experienced with the tick-stack, maybe this could be removed from telegraf-ds?