### PR TITLE
Add the option to automatically install TICK scripts from a specified directory

### DIFF
--- a/kapacitor/README.md
+++ b/kapacitor/README.md
@@ -7,7 +7,7 @@
 ## QuickStart
 
 ```bash
-$ helm install stable/kapacitor --name foo --namespace bar
+$ helm install --wait stable/kapacitor --name foo --namespace bar
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart bootstraps A Kapacitor deployment and service on a Kubernetes cluster
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/kapacitor
+$ helm install --wait --name my-release stable/kapacitor
 ```
 
 The command deploys Kapacitor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -64,6 +64,22 @@ $ helm install --name my-release -f values.yaml stable/kapacitor
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Automatic TICK script installation
+
+TICK scripts can be installed from a specified directory via a Kubernetes job
+with Helm `post-install` and `post-upgrade` hooks. It's disabled by default. To
+enable use:
+
+```bash
+$ helm install --name my-release \
+  --set "install_tick_scripts.enabled=true" \
+  --set "install_tick_scripts.tick_dir=/tick" \
+  --set "install_tick_scripts.kapacitorURL=http://kapacitor:9092" \
+  -f values.yaml stable/kapacitor
+```
+
+Or modify the default values in `values.yaml`.
 
 ## Persistence
 

--- a/kapacitor/templates/tickscript-init-job.yaml
+++ b/kapacitor/templates/tickscript-init-job.yaml
@@ -1,0 +1,74 @@
+{{if .Values.install_tick_scripts.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-init
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  init.sh: |-
+    #!/usr/bin/env bash
+    export KAPACITOR_URL={{ .Values.install_tick_scripts.kapacitorURL }}
+    ls -al $TICK_DIR
+    kapacitor list tasks
+
+    echo "Loading TICK files from $TICK_DIR"
+    for f in ${TICK_DIR}/*.tick
+    do
+        name="$(basename $f)"
+        name="${name/.tick/}"
+        kapacitor define $name \
+            -type batch \
+            -dbrp telegraf.autogen \
+            -tick $f
+        kapacitor enable $name
+    done
+    echo DONE
+    kapacitor list tasks
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" . }}-init-job
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+    app: {{ template "fullname" . }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}"
+      labels:
+        heritage: {{.Release.Service | quote }}
+        release: {{.Release.Name | quote }}
+        chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: ["bash", "/init/init.sh"]
+        env:
+          - name: TICK_DIR
+            value: "{{ .Values.install_tick_scripts.tick_dir }}"
+        volumeMounts:
+        - name: alerts
+          mountPath: /tick
+        - name: init
+          mountPath: /init
+      volumes:
+      - name: alerts
+        configMap:
+          name: {{ template "fullname" . }}-alerts
+      - name: init
+        configMap:
+          name: {{ template "fullname" . }}-init
+{{- end }}

--- a/kapacitor/values.yaml
+++ b/kapacitor/values.yaml
@@ -39,3 +39,12 @@ resources:
 ## ref: https://docs.influxdata.com/kapacitor/v1.1/introduction/getting_started/
 ##
 influxURL: http://data-influxdb.tick:8086
+
+
+## A Kubernetes Job can be used to install TICK scripts from a specified
+## tick_dir directory, if enabled.
+##
+install_tick_scripts:
+  kapacitorURL: http://kapacitor:9092
+  enabled: false
+  tick_dir: /tick


### PR DESCRIPTION
As requested in https://github.com/influxdata/kapacitor/issues/1313