### PR TITLE
Fix bug where new line wasn't added

### DIFF
--- a/influxdb/templates/deployment.yaml
+++ b/influxdb/templates/deployment.yaml
@@ -22,24 +22,24 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
         - name: api
-          containerPort: {{ .Values.config.http.bind_address -}}
-        {{- if .Values.config.admin.enabled -}}
+          containerPort: {{ .Values.config.http.bind_address }}
+        {{- if .Values.config.admin.enabled }}
         - name: admin
           containerPort: {{ .Values.config.admin.bind_address }}
         {{- end }}
-        {{- if .Values.config.graphite.enabled -}}
+        {{- if .Values.config.graphite.enabled }}
         - name: graphite
           containerPort: {{ .Values.config.graphite.bind_address }}
         {{- end }}
-        {{- if .Values.config.collectd.enabled -}}
+        {{- if .Values.config.collectd.enabled }}
         - name: collectd
           containerPort: {{ .Values.config.collectd.bind_address }}
         {{- end }}
-        {{- if .Values.config.udp.enabled -}}
+        {{- if .Values.config.udp.enabled }}
         - name: udp
           containerPort: {{ .Values.config.udp.bind_address }}
         {{- end }}
-        {{- if .Values.config.opentsdb.enabled -}}
+        {{- if .Values.config.opentsdb.enabled }}
         - name: opentsdb
           containerPort: {{ .Values.config.opentsdb.bind_address }}
         {{- end }}


### PR DESCRIPTION
When you have two input sinks enabled, a new line isn't added in the deployment.