### PR TITLE
Update service.yaml to specify udp as needed

### DIFF
--- a/telegraf-s/templates/service.yaml
+++ b/telegraf-s/templates/service.yaml
@@ -17,6 +17,7 @@ spec:
     {{- if eq $key "statsd" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    protocol: "UDP"
     name: "statsd"
     {{- end }}
     {{- if eq $key "tcp-listener" }}
@@ -27,6 +28,7 @@ spec:
     {{- if eq $key "udp-listener" }}
   - port: {{ trimPrefix ":" $value.service_address | int64 }}
     targetPort: {{ trimPrefix ":" $value.service_address | int64 }}
+    protocol: "UDP"
     name: "udp_listener"
     {{- end }}
     {{- if eq $key "webhooks" }}


### PR DESCRIPTION
For the polling-telegraf-s instance, the service.yaml template does not specify a protocol for the defined ports, so they default to TCP. udp_listener and statsd inputs assume UDP. This results in telegraf listening on a UDP port while the service defines a corresponding TCP port. 

Previously: 
`polling-telegraf-s ClusterIP 10.0.201.13 <none> 8125/TCP 14s`

With protocol specified in service.yaml: 
`polling-telegraf-s ClusterIP 10.0.129.228 <none> 8125/UDP 42s`
 