### PR TITLE
Update values.yaml

### DIFF
--- a/telegraf-s/values.yaml
+++ b/telegraf-s/values.yaml
@@ -219,7 +219,7 @@ config:
       timeout: "5s"
     kapacitor:
       urls:
-        - "http://kap-kapacitor.tick:9092/debug/vars"
+        - "http://alerts-kapacitor.tick:9092/debug/vars"
       timeout: "5s"
 ##      lustre2:
 ##        ost_procfiles:


### PR DESCRIPTION
Hi, shouldnt it be `alerts-kapacitor` instead of `kap-kapacitor` to match the kapacitor helm chart?