### PR TITLE
[Telegraf] Updated port for kubelet metrics collection

### DIFF
--- a/telegraf-ds/values.yaml
+++ b/telegraf-ds/values.yaml
@@ -46,7 +46,7 @@ config:
         insecure_skip_verify: false
   inputs:
     - kubernetes:
-        url: "http://$HOSTIP:10255"
+        url: "https://$HOSTIP:10250"
         bearer_token: "/var/run/secrets/kubernetes.io/serviceaccount/token"
         insecure_skip_verify: true
     - docker: 


### PR DESCRIPTION
Port 10255, which is readonly and with no auth is disabled from
v1.11 and replaced by 10250, a secured one.