### PR TITLE
Fix invalid template value in telegraf-ds

### DIFF
--- a/telegraf-ds/templates/_helpers.tpl
+++ b/telegraf-ds/templates/_helpers.tpl
@@ -81,7 +81,7 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
           {{- end }}
           {{- if eq $tp "int" }}
       {{ $key }} = {{ $value | int64 }}
-          {{- end }}s
+          {{- end }}
           {{- if eq $tp "bool" }}
       {{ $key }} = {{ $value }}
           {{- end }}


### PR DESCRIPTION
The template contains a bug: there is an "s" floating around which causes invalid toml configurations to be generated.