### PR TITLE
Configure env vars

### DIFF
--- a/chronograf/Chart.yaml
+++ b/chronograf/Chart.yaml
@@ -1,5 +1,5 @@
 name: chronograf
-version: 1.7.3
+version: 1.7.4
 description: Chart for Chronograf
 keywords:
 - chronograf

--- a/chronograf/README.md
+++ b/chronograf/README.md
@@ -69,3 +69,32 @@ $ helm install --name my-release -f values.yaml stable/chronograf
 The [Chronograf](https://quay.io/influxdb/chronograf) image stores data in the `/var/lib/chronograf` directory in the container.
 
 The chart optionally mounts a [Persistent Volume](kubernetes.io/docs/user-guide/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning.
+
+## OAuth Using Kubernetes Secret
+
+OAuth, among other things, can be configured in Chronograf using environment variables. For more information please see https://docs.influxdata.com/chronograf/latest/administration/managing-security
+
+Taking Google as an example, to use an existing Kubernetes Secret that contains sensitive information (`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`), e.g.:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chronograf-google-env-secrets
+  namespace: tick
+type: Opaque
+data:
+    GOOGLE_CLIENT_ID: <BASE64_ENCODED_GOOGLE_CLIENT_ID>
+    GOOGLE_CLIENT_SECRET: <BASE64_ENCODED_GOOGLE_CLIENT_SECRET>
+```
+
+in conjunction with less sensitive information such as `GOOGLE_DOMAINS` and `PUBLIC_URL`, one can make use of the chart's `envFromSecret` and `env` values, e.g. a values file can have the following:
+
+```
+[...]
+env:
+  GOOGLE_DOMAINS: "yourdomain.com"
+  PUBLIC_URL: "https://chronograf.yourdomain.com"
+envFromSecret: chronograf-google-env-secrets
+[...]
+```

--- a/chronograf/templates/deployment.yaml
+++ b/chronograf/templates/deployment.yaml
@@ -22,8 +22,12 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-{{- if .Values.oauth.enabled }}
         env:
+{{- range $key, $value := .Values.env }}
+        - name: "{{ $key }}"
+          value: "{{ $value }}"
+{{- end }}
+{{- if .Values.oauth.enabled }}
         - name: TOKEN_SECRET
           valueFrom:
             secretKeyRef:
@@ -85,6 +89,11 @@ spec:
               name: {{ template "fullname" . }}
               key: go_public_url
 {{- end }}
+{{- end }}
+{{- if .Values.envFromSecret }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.envFromSecret }}
 {{- end }}
         ports:
         - containerPort: 8888

--- a/chronograf/values.yaml
+++ b/chronograf/values.yaml
@@ -92,7 +92,7 @@ oauth:
     # This is a comma seperated list of Heroku organizations (OPTIONAL)
     he_orgs: ""
 
-## Extra environment variables that will be pass onto deployment pods
+## Extra environment variables that will be passed onto deployment pods
 env: {}
 
 ## The name of a secret in the same kubernetes namespace which contain values to be added to the environment

--- a/chronograf/values.yaml
+++ b/chronograf/values.yaml
@@ -91,3 +91,10 @@ oauth:
     client_secret: CHANGE_ME
     # This is a comma seperated list of Heroku organizations (OPTIONAL)
     he_orgs: ""
+
+## Extra environment variables that will be pass onto deployment pods
+env: {}
+
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+## This can be useful for auth tokens, etc
+envFromSecret: ""


### PR DESCRIPTION
Inspired by grafana's helm chart, where we can use a k8s secret to populate env vars, and also add our own env vars, this change will allow a user to do just that. In my particular case, I prefer to use a k8s secret to populate OAUTH related env vars for example.

cc @jackzampolin @timhallinflux 