### PR TITLE
Using same configmap style for telegraf-s and telegraf-ds

### DIFF
--- a/telegraf-ds/templates/_helpers.tpl
+++ b/telegraf-ds/templates/_helpers.tpl
@@ -21,6 +21,34 @@ We truncate at 24 chars because some Kubernetes name fields are limited to this 
   - agent section
 */}}
 
+{{- define "global_tags" -}}
+{{- if . -}}
+[global_tags]
+  {{- range $key, $val := . }}
+      {{ $key }} = {{ $val | quote }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "agent" -}}
+[agent]
+{{- range $key, $value := . -}}
+  {{- $tp := typeOf $value }}
+  {{- if eq $tp "string"}}
+      {{ $key }} = {{ $value | quote }}
+  {{- end }}
+  {{- if eq $tp "float64"}}
+      {{ $key }} = {{ $value | int64 }}
+  {{- end }}
+  {{- if eq $tp "int"}}
+      {{ $key }} = {{ $value | int64 }}
+  {{- end }}
+  {{- if eq $tp "bool"}}
+      {{ $key }} = {{ $value }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "outputs" -}}
 {{- range $outputIdx, $configObject := . -}}
 {{- range $output, $config := . }}

--- a/telegraf-ds/templates/configmap.yaml
+++ b/telegraf-ds/templates/configmap.yaml
@@ -10,26 +10,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
 data:
   telegraf.conf: |+
-    {{- if .Values.config.global_tags }}
-    [global_tags]
-      {{- range $key, $val := .Values.config.global_tags }}
-      {{ $key }} = {{ $val | quote }}
-      {{- end }}
-    {{- end }}
-    [agent]
-      interval = {{ .Values.config.agent.interval | quote }}
-      round_interval = {{ .Values.config.agent.round_interval }}
-      metric_batch_size = {{ .Values.config.agent.metric_batch_size }}
-      metric_buffer_limit = {{ .Values.config.agent.metric_buffer_limit }}
-      collection_jitter = {{ .Values.config.agent.collection_jitter | quote }}
-      flush_interval = {{ .Values.config.agent.flush_interval | quote }}
-      flush_jitter = {{ .Values.config.agent.flush_jitter | quote }}
-      precision = ""
-      debug = false
-      quiet = true
-      logfile = ""
-      hostname = "$HOSTNAME"
-      omit_hostname = false
-
+    {{ template "global_tags" .Values.config.global_tags }}
+    {{ template "agent" .Values.config.agent }}
     {{ template "outputs" .Values.config.outputs }}
     {{ template "inputs" .Values.config.inputs -}}

--- a/telegraf-ds/values.yaml
+++ b/telegraf-ds/values.yaml
@@ -34,6 +34,12 @@ config:
     collection_jitter: "0s"
     flush_interval: "10s"
     flush_jitter: "0s"
+    precision: ""
+    debug: false
+    quiet: false
+    logfile: ""
+    hostname: "$HOSTNAME"
+    omit_hostname: false
   outputs:
     - influxdb:
         url: "http://data-influxdb.tick:8086"


### PR DESCRIPTION
Regarding issue #42, 
I made small changes to `telegraf-ds` to use same configmap style as `telegraf-s` for better flexibility.
