### PR TITLE
override name if name contains chart name

### DIFF
--- a/influxdb/templates/NOTES.txt
+++ b/influxdb/templates/NOTES.txt
@@ -1,15 +1,15 @@
 InfluxDB can be accessed via port {{ .Values.config.http.bind_address }} on the following DNS name from within your cluster:
 
-- http://{{ template "fullname" . }}.{{ .Release.Namespace }}:{{ .Values.config.http.bind_address }}
+- http://{{ template "influxdb.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.config.http.bind_address }}
 
 You can easily connect to the remote instance with your local influx cli. To forward the API port to localhost:8086 run the following:
 
-- kubectl port-forward --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }} -o jsonpath='{ .items[0].metadata.name }') 8086:{{ .Values.config.http.bind_address }}
+- kubectl port-forward --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "influxdb.fullname" . }} -o jsonpath='{ .items[0].metadata.name }') 8086:{{ .Values.config.http.bind_address }}
 
 You can also connect to the influx cli from inside the container. To open a shell session in the InfluxDB pod run the following:
 
-- kubectl exec -i -t --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }} -o jsonpath='{.items[0].metadata.name}') /bin/sh
+- kubectl exec -i -t --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "influxdb.fullname" . }} -o jsonpath='{.items[0].metadata.name}') /bin/sh
 
 To tail the logs for the InfluxDB pod run the following:
 
-- kubectl logs -f --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "fullname" . }} -o jsonpath='{ .items[0].metadata.name }')
+- kubectl logs -f --namespace {{ .Release.Namespace }} $(kubectl get pods --namespace {{ .Release.Namespace }} -l app={{ template "influxdb.fullname" . }} -o jsonpath='{ .items[0].metadata.name }')

--- a/influxdb/templates/_helpers.tpl
+++ b/influxdb/templates/_helpers.tpl
@@ -2,15 +2,31 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "influxdb.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
+{{- define "influxdb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "influxdb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/influxdb/templates/config.yaml
+++ b/influxdb/templates/config.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "influxdb.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -80,9 +80,9 @@ data:
       unix-socket-enabled = {{ .Values.config.http.unix_socket_enabled }}
       bind-socket = "{{ .Values.config.http.bind_socket }}"
       flux-enabled = {{ .Values.config.http.flux_enabled }}
-    
+
     # TODO: allow multiple graphite listeners with templates
-    
+
     [[graphite]]
       enabled = {{ .Values.config.graphite.enabled }}
       bind-address = ":{{ .Values.config.graphite.bind_address }}"
@@ -95,7 +95,7 @@ data:
       consistency-level = "{{ .Values.config.graphite.consistency_level }}"
       separator = "{{ .Values.config.graphite.separator }}"
       udp-read-buffer = {{ .Values.config.graphite.udp_read_buffer | int64 }}
-    
+
     # TODO: allow multiple collectd listeners with templates
 
     [[collectd]]
@@ -110,7 +110,7 @@ data:
       typesdb = "{{ .Values.config.collectd.typesdb }}"
       security-level = "{{ .Values.config.collectd.security_level }}"
       auth-file = "{{ .Values.config.collectd.auth_file }}"
-    
+
     # TODO: allow multiple opentsdb listeners with templates
 
     [[opentsdb]]
@@ -125,7 +125,7 @@ data:
       batch-pending = {{ .Values.config.opentsdb.batch_pending | int64 }}
       batch-timeout = "{{ .Values.config.opentsdb.batch_timeout }}"
       log-point-errors = {{ .Values.config.opentsdb.log_point_errors }}
-    
+
     # TODO: allow multiple udp listeners with templates
 
     [[udp]]

--- a/influxdb/templates/deployment.yaml
+++ b/influxdb/templates/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "influxdb.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -12,14 +12,14 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "fullname" . }}
+        app: {{ template "influxdb.fullname" . }}
       annotations:
         # Include a hash of the config in the pod template
         # This means that if the config changes, the deployment will be rolled
         checksum/config: {{ include (print .Template.BasePath "/config.yaml") . | sha256sum }}
     spec:
       containers:
-      - name: {{ template "fullname" . }}
+      - name: {{ template "influxdb.fullname" . }}
         image: "{{ .Values.image.repo }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         resources:
@@ -76,10 +76,10 @@ spec:
       - name: data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}
+          claimName: {{ template "influxdb.fullname" . }}
       {{- else }}
         emptyDir: {}
       {{- end }}
       - name: config
         configMap:
-          name: {{ template "fullname" . }}
+          name: {{ template "influxdb.fullname" . }}

--- a/influxdb/templates/pvc.yaml
+++ b/influxdb/templates/pvc.yaml
@@ -2,9 +2,9 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "influxdb.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/influxdb/templates/service.yaml
+++ b/influxdb/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "influxdb.fullname" . }}
   labels:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
@@ -41,4 +41,4 @@ spec:
     targetPort: {{ .Values.config.rpc.bind_address }}
   {{- end }}
   selector:
-    app: {{ template "fullname" . }}
+    app: {{ template "influxdb.fullname" . }}


### PR DESCRIPTION
Hi, this is to be able to deploy a realse name `influxdb` instead of  `influxdb-influxdb`... This is the standard helpers file for charts at the moment btw.

Trying to get this in stable repo as well https://github.com/helm/charts/pull/10783

TIA