### PR TITLE
[influxdb] Add parameter for existing volume claim

### DIFF
--- a/influxdb/Chart.yaml
+++ b/influxdb/Chart.yaml
@@ -1,5 +1,5 @@
 name: influxdb
-version: 1.7.4
+version: 1.8.0
 description: Scalable datastore for metrics, events, and real-time analytics.
 keywords:
 - influxdb

--- a/influxdb/README.md
+++ b/influxdb/README.md
@@ -70,3 +70,4 @@ $ helm install --name my-release -f values.yaml stable/influxdb
 The [InfluxDB](https://hub.docker.com/_/influxdb/) image stores data in the `/var/lib/influxdb` directory in the container.
 
 The chart mounts a [Persistent Volume](kubernetes.io/docs/user-guide/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning.
+You can use `persistence.existingClaim` to use an existing claim instead of a dynamically provisioned one.

--- a/influxdb/templates/deployment.yaml
+++ b/influxdb/templates/deployment.yaml
@@ -76,7 +76,11 @@ spec:
       - name: data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "fullname" . }}
+        {{- if .Values.persistence.existingClaim }}
+          claimName: {{ .Values.persistence.existingClaim }}
+        {{- else}}
+          claimName: {{ template "fullname" . }}          
+        {{- end}}
       {{- else }}
         emptyDir: {}
       {{- end }}

--- a/influxdb/templates/pvc.yaml
+++ b/influxdb/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim)}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/influxdb/values.yaml
+++ b/influxdb/values.yaml
@@ -16,6 +16,9 @@ service:
 ##
 persistence:
   enabled: false
+  ## If defined, existing pvc will be used instead of creating a new one
+  ## accessMode and size parameters will be ignored when using an existing claim
+  # existingClaim: 
   ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
   ## Default: volume.alpha.kubernetes.io/storage-class: default
   ##


### PR DESCRIPTION
Add an option to use an existing volume claim for influxdb data.
This is handy when you want to upgrade, create or even delete the helm release without having to worry about accidentally deleting the stored data.