### PR TITLE
Pod Annotations on All Charts

### DIFF
--- a/chronograf/templates/deployment.yaml
+++ b/chronograf/templates/deployment.yaml
@@ -17,7 +17,9 @@ spec:
         # Include a hash of the secret in the pod template
         # This means that if the secret changes, the deployment will be rolled
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/chronograf/templates/deployment.yaml
+++ b/chronograf/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         # Include a hash of the secret in the pod template
         # This means that if the secret changes, the deployment will be rolled
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/chronograf/values.yaml
+++ b/chronograf/values.yaml
@@ -1,5 +1,5 @@
 ## Image Settings
-## 
+##
 ## ref: https://hub.docker.com/r/library/chronograf/tags/
 image:
   repository: "chronograf"
@@ -55,10 +55,15 @@ tolerations: []
 ##
 affinity: {}
 
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
 ## Configure the ingress object to hook into existing infastructure
 ## ref : http://kubernetes.io/docs/user-guide/ingress/
-## OPTIONALLY you can set .Values.ingress.secretName to set which secret to use    
-## 
+## OPTIONALLY you can set .Values.ingress.secretName to set which secret to use
+##
 ingress:
   enabled: false
   tls: false

--- a/influxdb/templates/deployment.yaml
+++ b/influxdb/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         # Include a hash of the config in the pod template
         # This means that if the config changes, the deployment will be rolled
         checksum/config: {{ include (print .Template.BasePath "/config.yaml") . | sha256sum }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       containers:
       - name: {{ template "fullname" . }}

--- a/influxdb/templates/deployment.yaml
+++ b/influxdb/templates/deployment.yaml
@@ -17,7 +17,9 @@ spec:
         # Include a hash of the config in the pod template
         # This means that if the config changes, the deployment will be rolled
         checksum/config: {{ include (print .Template.BasePath "/config.yaml") . | sha256sum }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ template "fullname" . }}

--- a/influxdb/values.yaml
+++ b/influxdb/values.yaml
@@ -52,6 +52,11 @@ tolerations: []
 ##
 affinity: {}
 
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
 ## Change InfluxDB configuration paramaters below:
 ## Defaults are indicated
 ## ref: https://docs.influxdata.com/influxdb/v1.7/administration/config/
@@ -168,4 +173,3 @@ config:
     log_enabled: true
     enabled: true
     run_interval: 1s
-

--- a/kapacitor/templates/deployment.yaml
+++ b/kapacitor/templates/deployment.yaml
@@ -18,7 +18,9 @@ spec:
         # Include a hash of the config in the pod template
         # This means that if the config changes, the deployment will be rolled
         checksum/config: {{ include (print .Template.BasePath "/config.yaml") . | sha256sum }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/kapacitor/templates/deployment.yaml
+++ b/kapacitor/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         # Include a hash of the config in the pod template
         # This means that if the config changes, the deployment will be rolled
         checksum/config: {{ include (print .Template.BasePath "/config.yaml") . | sha256sum }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/kapacitor/values.yaml
+++ b/kapacitor/values.yaml
@@ -54,6 +54,11 @@ tolerations: []
 ##
 affinity: {}
 
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
 ## Set the URL of InfluxDB instance to create subscription on
 ## ref: https://docs.influxdata.com/kapacitor/v1.5/introduction/getting_started/
 ##

--- a/telegraf-ds/templates/daemonset.yaml
+++ b/telegraf-ds/templates/daemonset.yaml
@@ -15,6 +15,7 @@ spec:
         # Include a hash of the configmap in the pod template
         # This means that if the configmap changes, the deployment will be rolled
         checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       containers:
       - name: {{ template "fullname" . }}

--- a/telegraf-ds/templates/daemonset.yaml
+++ b/telegraf-ds/templates/daemonset.yaml
@@ -15,7 +15,9 @@ spec:
         # Include a hash of the configmap in the pod template
         # This means that if the configmap changes, the deployment will be rolled
         checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ template "fullname" . }}

--- a/telegraf-ds/values.yaml
+++ b/telegraf-ds/values.yaml
@@ -21,6 +21,11 @@ resources:
 ##
 tolerations: []
 
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
 ## Exposed telegraf configuration
 ## ref: https://docs.influxdata.com/telegraf/v1.8/administration/configuration/
 config:
@@ -55,7 +60,7 @@ config:
         url: "https://$HOSTIP:10250"
         bearer_token: "/var/run/secrets/kubernetes.io/serviceaccount/token"
         insecure_skip_verify: true
-    - docker: 
+    - docker:
         endpoint: "unix:///var/run/docker.sock"
         timeout: "5s"
         perdevice: true

--- a/telegraf-s/templates/deployment.yaml
+++ b/telegraf-s/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         # Include a hash of the configmap in the pod template
         # This means that if the configmap changes, the deployment will be rolled
         checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       containers:
       - name: {{ template "fullname" . }}

--- a/telegraf-s/templates/deployment.yaml
+++ b/telegraf-s/templates/deployment.yaml
@@ -16,7 +16,9 @@ spec:
         # Include a hash of the configmap in the pod template
         # This means that if the configmap changes, the deployment will be rolled
         checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       containers:
       - name: {{ template "fullname" . }}

--- a/telegraf-s/values.yaml
+++ b/telegraf-s/values.yaml
@@ -38,6 +38,11 @@ tolerations: []
 ##
 affinity: {}
 
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+
 ## Configure the service for this telegraf instance. If you are running
 ## Any of the service plugins you will need this enabled
 ## Service Plugins: http_listener, statsd, tcp_listener, udp_listener
@@ -136,7 +141,7 @@ config:
 ##        server: "localhost:4150"
 ##        topic: "telegraf"
 ##        data_format: "influx"
-  
+
 # CPU and System is required for chronograf
 # This may show errors in the logs, but this does not affect performance or functionality
   inputs:
@@ -400,4 +405,3 @@ config:
         metric_separator: "_"
         allowed_pending_messages: 10000
         percentile_limit: 1000
-


### PR DESCRIPTION
This change adds pod annotations on the deployments for all charts. These can be necessary for working with other services on k8s and they are pretty standard chart feature.