### PR TITLE
Adding protocols to port names

### DIFF
--- a/chronograf/templates/deployment.yaml
+++ b/chronograf/templates/deployment.yaml
@@ -97,15 +97,15 @@ spec:
 {{- end }}
         ports:
         - containerPort: 8888
-          name: api
+          name: http-api
         livenessProbe:
           httpGet:
             path: /ping
-            port: api
+            port: http-api
         readinessProbe:
           httpGet:
             path: /ping
-            port: api
+            port: http-api
         volumeMounts:
         - name: data
           mountPath: /var/lib/chronograf

--- a/chronograf/templates/service.yaml
+++ b/chronograf/templates/service.yaml
@@ -12,5 +12,6 @@ spec:
   ports:
   - port: 80
     targetPort: 8888
+    name: http-api
   selector:
     app: {{ template "fullname" . }}

--- a/influxdb/templates/_helpers.tpl
+++ b/influxdb/templates/_helpers.tpl
@@ -14,3 +14,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "apiPortName" -}}
+{{- if .Values.config.http.https_enabled -}}https-api{{- else -}}http-api{{- end -}}
+{{- end -}}

--- a/influxdb/templates/deployment.yaml
+++ b/influxdb/templates/deployment.yaml
@@ -25,34 +25,35 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
-        - name: api
+        - name: {{ template "apiPortName" . }}
           containerPort: {{ .Values.config.http.bind_address }}
         {{- if .Values.config.graphite.enabled }}
-        - name: graphite
+        - name: tcp-graphite
           containerPort: {{ .Values.config.graphite.bind_address }}
         {{- end }}
         {{- if .Values.config.collectd.enabled }}
-        - name: collectd
+        - name: tcp-collectd
           containerPort: {{ .Values.config.collectd.bind_address }}
         {{- end }}
         {{- if .Values.config.udp.enabled }}
         - name: udp
           containerPort: {{ .Values.config.udp.bind_address }}
+          protocol: UDP
         {{- end }}
         {{- if .Values.config.opentsdb.enabled }}
-        - name: opentsdb
+        - name: tcp-opentsdb
           containerPort: {{ .Values.config.opentsdb.bind_address }}
         {{- end }}
         livenessProbe:
           httpGet:
             path: /ping
-            port: api
+            port: {{ template "apiPortName" . }}
           initialDelaySeconds: 30
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /ping
-            port: api
+            port: {{ template "apiPortName" . }}
           initialDelaySeconds: 5
           timeoutSeconds: 1
         volumeMounts:

--- a/influxdb/templates/service.yaml
+++ b/influxdb/templates/service.yaml
@@ -11,17 +11,17 @@ spec:
   type: {{ .Values.service.type }}
   ports:
   {{- if .Values.config.http.enabled }}
-  - name: api
+  - name: {{ template "apiPortName" . }}
     port: {{ .Values.config.http.bind_address }}
     targetPort: {{ .Values.config.http.bind_address }}
   {{- end }}
   {{- if .Values.config.graphite.enabled }}
-  - name: graphite
+  - name: tcp-graphite
     port: {{ .Values.config.graphite.bind_address }}
     targetPort: {{ .Values.config.graphite.bind_address }}
   {{- end }}
   {{- if .Values.config.collectd.enabled }}
-  - name: collectd
+  - name: tcp-collectd
     port: {{ .Values.config.collectd.bind_address }}
     targetPort: {{ .Values.config.collectd.bind_address }}
   {{- end }}
@@ -29,14 +29,15 @@ spec:
   - name: udp
     port: {{ .Values.config.udp.bind_address }}
     targetPort: {{ .Values.config.udp.bind_address }}
+
   {{- end }}
   {{- if .Values.config.opentsdb.enabled }}
-  - name: opentsdb
+  - name: tcp-opentsdb
     port: {{ .Values.config.opentsdb.bind_address }}
     targetPort: {{ .Values.config.opentsdb.bind_address }}
   {{- end }}
   {{- if .Values.config.rpc.enabled }}
-  - name: rpc
+  - name: http-rpc
     port: {{ .Values.config.rpc.bind_address }}
     targetPort: {{ .Values.config.rpc.bind_address }}
   {{- end }}

--- a/kapacitor/templates/_helpers.tpl
+++ b/kapacitor/templates/_helpers.tpl
@@ -14,3 +14,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "apiPortName" -}}
+{{- if .Values.config.http.https_enabled -}}https-api{{- else -}}http-api{{- end -}}
+{{- end -}}

--- a/kapacitor/templates/_helpers.tpl
+++ b/kapacitor/templates/_helpers.tpl
@@ -14,7 +14,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{- define "apiPortName" -}}
-{{- if .Values.config.http.https_enabled -}}https-api{{- else -}}http-api{{- end -}}
-{{- end -}}

--- a/kapacitor/templates/service.yaml
+++ b/kapacitor/templates/service.yaml
@@ -12,6 +12,6 @@ spec:
   ports:
   - port: 9092
     targetPort: 9092
-    name: {{ template "apiPortName" . }}
+    name: http-api
   selector:
     app: {{ template "fullname" . }}

--- a/kapacitor/templates/service.yaml
+++ b/kapacitor/templates/service.yaml
@@ -12,6 +12,6 @@ spec:
   ports:
   - port: 9092
     targetPort: 9092
-    name: api
+    name: {{ template "apiPortName" . }}
   selector:
     app: {{ template "fullname" . }}


### PR DESCRIPTION
This change adds protocol information to all charts, with the exception of telegraf, which already does this. There shouldn't be any impact to the applications from this, but it should improve Istio's handling of the services (see https://istio.io/docs/setup/kubernetes/prepare/requirements/).