### PR TITLE
fixes google oauth typo in chronograf values.yaml

### DIFF
--- a/chronograf/values.yaml
+++ b/chronograf/values.yaml
@@ -88,7 +88,7 @@ oauth:
     client_secret: CHANGE_ME
     public_url: "" # eg. http://chronograf.foobar.com
     # This is a comma seperated list of Google Apps domains (OPTIONAL)
-    google_domains: ""
+    domains: ""
   heroku:
     enabled: false
     client_id: CHANGE_ME


### PR DESCRIPTION
The chronograf values.yaml file had a simple typo making it not match
the structure of the templates. This breaks chronograf install if
using Google OAUTH.