### PR TITLE
Allow service account to be set for Telegraf-DS

### DIFF
--- a/telegraf-ds/templates/daemonset.yaml
+++ b/telegraf-ds/templates/daemonset.yaml
@@ -57,6 +57,9 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       volumes:
       - name: sysro
         hostPath:

--- a/telegraf-ds/values.yaml
+++ b/telegraf-ds/values.yaml
@@ -21,6 +21,9 @@ resources:
 ##
 tolerations: []
 
+# Pod service account
+# serviceAccountName: ""
+
 ## Exposed telegraf configuration
 ## ref: https://docs.influxdata.com/telegraf/v1.8/administration/configuration/
 config:


### PR DESCRIPTION
This is the same change from #92 applied to the telegraf-ds chart.

Fixes #105