### PR TITLE
Support for rbac

### DIFF
--- a/telegraf-ds/templates/rbac.yaml
+++ b/telegraf-ds/templates/rbac.yaml
@@ -1,0 +1,39 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ template "fullname" . }}
+---
+kind: ClusterRole
+{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+metadata:
+  name: {{ template "fullname" . }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/stats
+    verbs:
+      - get
+---
+kind: ClusterRoleBinding
+{{- if semverCompare "^1.8-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
+metadata:
+  name: {{ template "fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+- kind: User
+  name: system:serviceaccount:monitoring:default

--- a/telegraf-ds/values.yaml
+++ b/telegraf-ds/values.yaml
@@ -55,6 +55,7 @@ config:
         url: "https://$HOSTIP:10250"
         bearer_token: "/var/run/secrets/kubernetes.io/serviceaccount/token"
         insecure_skip_verify: true
+        tls_ca: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
     - docker: 
         endpoint: "unix:///var/run/docker.sock"
         timeout: "5s"
@@ -62,3 +63,17 @@ config:
         total: false
         docker_label_exclude:
           - "annotation.kubernetes.io/*"
+    - prometheus:
+        urls:
+          - "http://your_prometheus_ip/metrics"
+        name_prefix: "prom_"
+        bearer_token: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        insecure_skip_verify: true
+    - cpu:
+    - system:
+    - disk:
+    - diskio:
+    - mem:
+    - processes:
+    - net:
+    - swap:


### PR DESCRIPTION
This has just one workaround line that needs to be modified depending on the namespace you are deploying the charts

`
- kind: User
  name: system:serviceaccount:monitoring:default
`

This is for RBAC support to not get

`
2019-08-30T16:43:10Z E! [inputs.kubernetes]: Error in plugin: https://XXX.XXX.XXX.XXX:10250/stats/summary returned HTTP status 403 Forbidden
`